### PR TITLE
Codex/1.19.2 dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,8 @@ run
 logs
 error*
 
+# local notes
+docs/
+
 # Files from Forge MDK
 forge*changelog.txt

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '6.+', changing: true
-        classpath 'org.parchmentmc:librarian:1.+'
+        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '6.0.54'
+        classpath 'org.parchmentmc:librarian:1.2.0.7-dev-SNAPSHOT'
         classpath group: 'org.spongepowered', name: 'mixingradle', version: '0.7-SNAPSHOT'
     }
 }
@@ -106,6 +106,13 @@ repositories {
             includeGroup "curse.maven"
         }
     }
+    maven {
+        name = "Modrinth"
+        url = "https://api.modrinth.com/maven"
+        content {
+            includeGroup "maven.modrinth"
+        }
+    }
 }
 
 dependencies {
@@ -114,7 +121,12 @@ dependencies {
     runtimeOnly fg.deobf("mezz.jei:jei-${mc_version}-forge:${jei_version}")
 
     implementation fg.deobf("appeng:appliedenergistics2-forge:${ae2_version}")
-    implementation fg.deobf('curse.maven:ae2wirelessterminals-459929:4655495')
+    compileOnly fg.deobf('curse.maven:ae2wirelessterminals-459929:4655495')
+    runtimeOnly fg.deobf('curse.maven:ae2wirelessterminals-459929:4655495')
+    compileOnly fg.deobf('maven.modrinth:applied-mekanistics:1.3.5')
+    compileOnly fg.deobf('maven.modrinth:mekanism:10.3.9.13')
+    compileOnly fg.deobf('maven.modrinth:applied-botanics:1.4.6-forge')
+    compileOnly fg.deobf('maven.modrinth:botania:1.19.2-440-forge')
     
     runtimeOnly fg.deobf('curse.maven:curios-309927:5843737')
     runtimeOnly fg.deobf('curse.maven:cloth-348521:5729096')

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ modid=ae2insertexportcard
 mc_version=1.19.2
 forge_version=43.4.0
 jei_version=11.6.0.1017
-ae2_version=12.9.12
+ae2_version=12.9.9

--- a/src/main/java/com/ultramega/ae2insertexportcard/AE2InsertExportCard.java
+++ b/src/main/java/com/ultramega/ae2insertexportcard/AE2InsertExportCard.java
@@ -17,6 +17,9 @@ public class AE2InsertExportCard {
     public static final String MOD_ID = "ae2insertexportcard";
 
     public static final NetworkHandler NETWORK_HANDLER = new NetworkHandler();
+    private static final java.util.Map<net.minecraft.world.item.ItemStack,
+            java.util.concurrent.Future<appeng.api.networking.crafting.ICraftingPlan>> CRAFTING_JOBS =
+                    java.util.Collections.synchronizedMap(new java.util.WeakHashMap<>());
 
     public AE2InsertExportCard() {
         DistExecutor.safeRunWhenOn(Dist.CLIENT, () -> ClientEventHandler::new);
@@ -46,11 +49,9 @@ public class AE2InsertExportCard {
     }
 
     public static void tickWireless(net.minecraft.world.item.ItemStack stack, appeng.api.networking.IGrid grid,
-            appeng.helpers.WirelessTerminalMenuHost host, net.minecraft.server.level.ServerPlayer player,
-            java.util.function.Supplier<java.util.concurrent.Future<appeng.api.networking.crafting.ICraftingPlan>> jobGetter,
-            java.util.function.Consumer<java.util.concurrent.Future<appeng.api.networking.crafting.ICraftingPlan>> jobSetter) {
+            appeng.helpers.WirelessTerminalMenuHost host, net.minecraft.server.level.ServerPlayer player) {
 
-        if (stack.getTag().contains("upgrades") && grid != null) {
+        if (stack.hasTag() && stack.getTag().contains("upgrades") && grid != null && host != null) {
             net.minecraft.nbt.ListTag tagList = stack.getTag().getList("upgrades", net.minecraft.nbt.Tag.TAG_COMPOUND);
 
             for (int i = 0; i < tagList.size(); i++) {
@@ -69,6 +70,9 @@ public class AE2InsertExportCard {
                 net.minecraft.nbt.CompoundTag tag = (net.minecraft.nbt.CompoundTag) tagList.getCompound(i).get("tag");
 
                 if (tag != null && (isInsertUpgrade || isExportUpgrade)) {
+                    if (slot < 0 || slot >= host.getUpgrades().size()) {
+                        continue;
+                    }
                     net.minecraft.world.item.ItemStack upgrade = host.getUpgrades().getStackInSlot(slot);
                     int[] selectedInventorySlots = tag.getIntArray(
                             com.ultramega.ae2insertexportcard.item.UpgradeHost.NBT_SELECTED_INVENTORY_SLOTS);
@@ -84,7 +88,9 @@ public class AE2InsertExportCard {
                         fuzzyMode = appeng.api.config.FuzzyMode.IGNORE_ALL;
                     }
 
-                    for (int j = 0; j < selectedInventorySlots.length; j++) {
+                    int inventorySlotCount = Math.min(selectedInventorySlots.length,
+                            player.getInventory().items.size());
+                    for (int j = 0; j < inventorySlotCount; j++) {
                         if (selectedInventorySlots[j] >= 1) {
                             net.minecraft.world.item.ItemStack itemInInventory = player.getInventory().getItem(j);
 
@@ -104,59 +110,76 @@ public class AE2InsertExportCard {
 
                                 if (isInsertUpgrade) {
                                     appeng.api.stacks.AEKey what = appeng.api.stacks.AEItemKey.of(itemInInventory);
-                                    if (what != null && grid.getStorageService() != null) {
+                                    if (grid.getStorageService() != null) {
+                                        boolean fuzzyInstalled = upgrades
+                                                .isInstalled(appeng.core.definitions.AEItems.FUZZY_CARD);
+                                        var energySource = new appeng.me.helpers.ChannelPowerSrc(node,
+                                                grid.getEnergyService());
+
+                                        if (com.ultramega.ae2insertexportcard.compat.AddonStorageBridge
+                                                .importFromItem(player, grid, energySource, source, j,
+                                                        itemInInventory, filterConfig, fuzzyMode, fuzzyInstalled,
+                                                        invertFilter)) {
+                                            continue;
+                                        }
+
                                         // Import Fluids
-                                        for (int index = 0; index < filterConfig.size(); index++) {
-                                            appeng.api.stacks.GenericStack filter = filterConfig.getStack(index);
-                                            if (filter != null
-                                                    && filter.what() instanceof appeng.api.stacks.AEFluidKey) {
-                                                itemInInventory.getCapability(
-                                                        net.minecraftforge.common.capabilities.ForgeCapabilities.FLUID_HANDLER_ITEM)
-                                                        .ifPresent((fluidItem -> {
-                                                            net.minecraftforge.fluids.FluidStack fluidStack = fluidItem
-                                                                    .drain(Integer.MAX_VALUE,
-                                                                            net.minecraftforge.fluids.capability.IFluidHandler.FluidAction.SIMULATE);
-                                                            if (fluidStack.isEmpty())
-                                                                return;
-
-                                                            appeng.api.stacks.AEFluidKey aeFluidKey = appeng.api.stacks.AEFluidKey
-                                                                    .of(fluidStack);
-                                                            if (aeFluidKey == null)
-                                                                return;
-
-                                                            long amount = appeng.api.storage.StorageHelper
-                                                                    .poweredInsert(
-                                                                            new appeng.me.helpers.ChannelPowerSrc(node,
-                                                                                    grid.getEnergyService()),
-                                                                            grid.getStorageService().getInventory(),
-                                                                            aeFluidKey,
-                                                                            fluidStack.getAmount(), source,
-                                                                            appeng.api.config.Actionable.SIMULATE);
-                                                            if (amount <= 0)
-                                                                return;
-
-                                                            fluidItem.drain((int) amount,
-                                                                    net.minecraftforge.fluids.capability.IFluidHandler.FluidAction.EXECUTE);
-                                                            appeng.api.storage.StorageHelper.poweredInsert(
-                                                                    new appeng.me.helpers.ChannelPowerSrc(node,
-                                                                            grid.getEnergyService()),
-                                                                    grid.getStorageService().getInventory(), aeFluidKey,
-                                                                    amount, source,
-                                                                    appeng.api.config.Actionable.MODULATE);
-                                                            player.containerMenu.broadcastChanges();
-                                                        }));
+                                        boolean importedFluid = false;
+                                        var fluidCapability = itemInInventory.getCapability(
+                                                net.minecraftforge.common.capabilities.ForgeCapabilities.FLUID_HANDLER_ITEM)
+                                                .resolve();
+                                        if (fluidCapability.isPresent()) {
+                                            var fluidItem = fluidCapability.get();
+                                            net.minecraftforge.fluids.FluidStack fluidStack = fluidItem.drain(
+                                                    Integer.MAX_VALUE,
+                                                    net.minecraftforge.fluids.capability.IFluidHandler.FluidAction.SIMULATE);
+                                            appeng.api.stacks.AEFluidKey fluidKey = fluidStack.isEmpty()
+                                                    ? null
+                                                    : appeng.api.stacks.AEFluidKey.of(fluidStack);
+                                            if (fluidKey != null
+                                                    && invertFilter != filterMatches(filterConfig, fluidKey, fuzzyMode,
+                                                            fuzzyInstalled)) {
+                                                long accepted = appeng.api.storage.StorageHelper.poweredInsert(
+                                                        new appeng.me.helpers.ChannelPowerSrc(node,
+                                                                grid.getEnergyService()),
+                                                        grid.getStorageService().getInventory(), fluidKey,
+                                                        fluidStack.getAmount(), source,
+                                                        appeng.api.config.Actionable.SIMULATE);
+                                                if (accepted > 0) {
+                                                    net.minecraftforge.fluids.FluidStack drained = fluidItem.drain(
+                                                            (int) Math.min(accepted, Integer.MAX_VALUE),
+                                                            net.minecraftforge.fluids.capability.IFluidHandler.FluidAction.EXECUTE);
+                                                    if (drained.isEmpty()) {
+                                                        continue;
+                                                    }
+                                                    long inserted = appeng.api.storage.StorageHelper.poweredInsert(
+                                                            new appeng.me.helpers.ChannelPowerSrc(node,
+                                                                    grid.getEnergyService()),
+                                                            grid.getStorageService().getInventory(), fluidKey,
+                                                            drained.getAmount(), source,
+                                                            appeng.api.config.Actionable.MODULATE);
+                                                    if (inserted < drained.getAmount()) {
+                                                        net.minecraftforge.fluids.FluidStack rollback = drained.copy();
+                                                        rollback.setAmount((int) (drained.getAmount() - inserted));
+                                                        fluidItem.fill(rollback,
+                                                                net.minecraftforge.fluids.capability.IFluidHandler.FluidAction.EXECUTE);
+                                                    }
+                                                    if (inserted > 0) {
+                                                        player.getInventory().setItem(j, fluidItem.getContainer());
+                                                        player.containerMenu.broadcastChanges();
+                                                        importedFluid = true;
+                                                    }
+                                                }
                                             }
+                                        }
+                                        if (importedFluid) {
+                                            continue;
                                         }
 
                                         // Import Items
-                                        final appeng.api.config.FuzzyMode finalFuzzyMode = fuzzyMode;
-                                        if (invertFilter != filterConfig.getAvailableStacks().findFuzzy(what, fuzzyMode)
-                                                .stream()
-                                                .anyMatch(filterKeyEntry -> upgrades
-                                                        .isInstalled(appeng.core.definitions.AEItems.FUZZY_CARD)
-                                                                ? what.fuzzyEquals(filterKeyEntry.getKey(),
-                                                                        finalFuzzyMode)
-                                                                : what.equals(filterKeyEntry.getKey()))) {
+                                        if (what != null
+                                                && invertFilter != filterMatches(filterConfig, what, fuzzyMode,
+                                                        fuzzyInstalled)) {
                                             long amount = appeng.api.storage.StorageHelper.poweredInsert(
                                                     new appeng.me.helpers.ChannelPowerSrc(node,
                                                             grid.getEnergyService()),
@@ -166,14 +189,17 @@ public class AE2InsertExportCard {
                                             if (amount <= 0)
                                                 continue;
 
-                                            appeng.api.storage.StorageHelper.poweredInsert(
+                                            long inserted = appeng.api.storage.StorageHelper.poweredInsert(
                                                     new appeng.me.helpers.ChannelPowerSrc(node,
                                                             grid.getEnergyService()),
                                                     grid.getStorageService().getInventory(), what,
-                                                    itemInInventory.getCount(), source,
+                                                    amount, source,
                                                     appeng.api.config.Actionable.MODULATE);
-                                            player.getInventory().setItem(j, net.minecraft.world.item.ItemStack.EMPTY);
-                                            player.containerMenu.broadcastChanges();
+                                            if (inserted > 0) {
+                                                itemInInventory.shrink((int) Math.min(inserted,
+                                                        itemInInventory.getCount()));
+                                                player.containerMenu.broadcastChanges();
+                                            }
                                         }
                                     }
                                 } else {
@@ -184,6 +210,32 @@ public class AE2InsertExportCard {
                                         if (index != selectedInventorySlots[j] - 1)
                                             continue;
 
+                                        appeng.api.stacks.AEKey addonExportKey;
+                                        if (upgrades.isInstalled(appeng.core.definitions.AEItems.FUZZY_CARD)) {
+                                            var fuzzy = grid.getStorageService().getCachedInventory()
+                                                    .findFuzzy(filter.what(), fuzzyMode)
+                                                    .stream().findFirst();
+                                            addonExportKey = fuzzy.map(java.util.Map.Entry::getKey).orElse(null);
+                                        } else {
+                                            addonExportKey = filter.what();
+                                        }
+
+                                        if (addonExportKey != null
+                                                && com.ultramega.ae2insertexportcard.compat.AddonStorageBridge
+                                                        .isSupportedKey(addonExportKey)) {
+                                            long operationAmount = addonExportKey.getType().getAmountPerOperation();
+                                            long requestedAmount = upgrades
+                                                    .isInstalled(appeng.core.definitions.AEItems.SPEED_CARD)
+                                                            ? operationAmount * 64L
+                                                            : operationAmount;
+                                            com.ultramega.ae2insertexportcard.compat.AddonStorageBridge.exportToItem(
+                                                    player, grid,
+                                                    new appeng.me.helpers.ChannelPowerSrc(node,
+                                                            grid.getEnergyService()),
+                                                    source, j, itemInInventory, addonExportKey, requestedAmount);
+                                            continue;
+                                        }
+
                                         java.util.Optional<net.minecraftforge.items.IItemHandler> playerInventory = player
                                                 .getCapability(
                                                         net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER,
@@ -192,20 +244,18 @@ public class AE2InsertExportCard {
                                         if (playerInventory.isPresent()) {
                                             appeng.api.stacks.AEItemKey what = appeng.api.stacks.AEItemKey
                                                     .of(itemInInventory.getItem());
-                                            boolean acceptsFluid = false;
-
-                                            var cap = itemInInventory
+                                            var fluidCapability = itemInInventory
                                                     .getCapability(
                                                             net.minecraftforge.common.capabilities.ForgeCapabilities.FLUID_HANDLER_ITEM)
-                                                    .cast();
-                                            if (cap.isPresent()) {
-                                                acceptsFluid = true;
-                                            }
+                                                    .resolve();
+                                            boolean acceptsFluid = fluidCapability.isPresent();
 
                                             if (acceptsFluid || itemInInventory.isEmpty()
-                                                    || (upgrades.isInstalled(appeng.core.definitions.AEItems.FUZZY_CARD)
-                                                            ? what.fuzzyEquals(filter.what(), fuzzyMode)
-                                                            : what.equals(filter.what()))) {
+                                                    || (what != null
+                                                            && (upgrades.isInstalled(
+                                                                    appeng.core.definitions.AEItems.FUZZY_CARD)
+                                                                            ? what.fuzzyEquals(filter.what(), fuzzyMode)
+                                                                            : what.equals(filter.what())))) {
                                                 appeng.api.stacks.AEKey toExportKey;
                                                 if (upgrades.isInstalled(appeng.core.definitions.AEItems.FUZZY_CARD)) {
                                                     var fuzzy = grid.getStorageService().getCachedInventory()
@@ -238,7 +288,7 @@ public class AE2InsertExportCard {
                                                                         grid.getStorageService().getInventory(),
                                                                         toExportKey,
                                                                         size, source,
-                                                                        appeng.api.config.Actionable.MODULATE);
+                                                                        appeng.api.config.Actionable.SIMULATE);
                                                         if (extracted <= 0) {
                                                             if (upgrades.isInstalled(
                                                                     appeng.core.definitions.AEItems.CRAFTING_CARD)) {
@@ -249,43 +299,70 @@ public class AE2InsertExportCard {
                                                                     var src = new appeng.me.helpers.MachineSource(
                                                                             grid::getPivot);
 
-                                                                    java.util.concurrent.Future<appeng.api.networking.crafting.ICraftingPlan> ae2insertExportCard$craftingJob = jobGetter
-                                                                            .get();
-
-                                                                    if (ae2insertExportCard$craftingJob != null) {
+                                                                    var craftingJob = CRAFTING_JOBS.get(stack);
+                                                                    if (craftingJob == null) {
+                                                                        CRAFTING_JOBS.put(stack, craftingService
+                                                                                .beginCraftingCalculation(
+                                                                                        player.getLevel(), () -> src,
+                                                                                        filter.what(), size,
+                                                                                        appeng.api.networking.crafting.CalculationStrategy.CRAFT_LESS));
+                                                                    } else if (craftingJob.isDone()) {
                                                                         try {
-                                                                            appeng.api.networking.crafting.ICraftingPlan job = null;
-                                                                            if (ae2insertExportCard$craftingJob
-                                                                                    .isDone()) {
-                                                                                job = ae2insertExportCard$craftingJob
-                                                                                        .get();
-                                                                            }
-
-                                                                            // Check if job is complete
+                                                                            var job = craftingJob.get();
                                                                             if (job != null) {
                                                                                 craftingService.submitJob(job, null,
                                                                                         null, false, src);
-
-                                                                                jobSetter.accept(null);
                                                                             }
-                                                                        } catch (InterruptedException
-                                                                                | java.util.concurrent.ExecutionException ignored) {
+                                                                        } catch (InterruptedException e) {
+                                                                            Thread.currentThread().interrupt();
+                                                                        } catch (java.util.concurrent.ExecutionException
+                                                                                | java.util.concurrent.CancellationException ignored) {
+                                                                        } finally {
+                                                                            CRAFTING_JOBS.remove(stack);
                                                                         }
                                                                     }
-
-                                                                    jobSetter.accept(craftingService
-                                                                            .beginCraftingCalculation(player.getLevel(),
-                                                                                    () -> src,
-                                                                                    filter.what(), size,
-                                                                                    appeng.api.networking.crafting.CalculationStrategy.CRAFT_LESS));
                                                                 }
                                                             }
 
                                                             continue;
                                                         }
 
-                                                        playerInventory.get().insertItem(j,
-                                                                fuzzyItem.toStack((int) extracted), false);
+                                                        net.minecraft.world.item.ItemStack candidate = fuzzyItem
+                                                                .toStack((int) extracted);
+                                                        net.minecraft.world.item.ItemStack simulatedRemainder = playerInventory
+                                                                .get().insertItem(j, candidate, true);
+                                                        int accepted = candidate.getCount()
+                                                                - simulatedRemainder.getCount();
+                                                        if (accepted <= 0) {
+                                                            continue;
+                                                        }
+
+                                                        long actuallyExtracted = appeng.api.storage.StorageHelper
+                                                                .poweredExtraction(
+                                                                        new appeng.me.helpers.ChannelPowerSrc(node,
+                                                                                grid.getEnergyService()),
+                                                                        grid.getStorageService().getInventory(),
+                                                                        toExportKey, accepted, source,
+                                                                        appeng.api.config.Actionable.MODULATE);
+                                                        if (actuallyExtracted <= 0) {
+                                                            continue;
+                                                        }
+
+                                                        net.minecraft.world.item.ItemStack remainder = playerInventory
+                                                                .get().insertItem(j,
+                                                                        fuzzyItem.toStack((int) actuallyExtracted),
+                                                                        false);
+                                                        if (!remainder.isEmpty()) {
+                                                            long returned = grid.getStorageService().getInventory()
+                                                                    .insert(toExportKey, remainder.getCount(),
+                                                                            appeng.api.config.Actionable.MODULATE,
+                                                                            source);
+                                                            remainder.shrink((int) returned);
+                                                            if (!remainder.isEmpty()
+                                                                    && !player.getInventory().add(remainder)) {
+                                                                player.drop(remainder, false);
+                                                            }
+                                                        }
                                                         player.containerMenu.broadcastChanges();
                                                     } else if (acceptsFluid
                                                             && toExportKey instanceof appeng.api.stacks.AEFluidKey fuzzyFluid) {
@@ -307,26 +384,36 @@ public class AE2InsertExportCard {
                                                             continue;
                                                         }
 
-                                                        cap.ifPresent((o -> {
-                                                            if (o instanceof net.minecraftforge.fluids.capability.IFluidHandlerItem fluidItem) {
-                                                                int amount = fluidItem.fill(
-                                                                        fuzzyFluid.toStack((int) extracted),
-                                                                        net.minecraftforge.fluids.capability.IFluidHandler.FluidAction.SIMULATE);
-                                                                if (amount <= 0) {
-                                                                    return;
-                                                                }
+                                                        var fluidItem = fluidCapability.get();
+                                                        int amount = fluidItem.fill(
+                                                                fuzzyFluid.toStack((int) extracted),
+                                                                net.minecraftforge.fluids.capability.IFluidHandler.FluidAction.SIMULATE);
+                                                        if (amount <= 0) {
+                                                            continue;
+                                                        }
 
-                                                                appeng.api.storage.StorageHelper.poweredExtraction(
+                                                        long actuallyExtracted = appeng.api.storage.StorageHelper
+                                                                .poweredExtraction(
                                                                         new appeng.me.helpers.ChannelPowerSrc(node,
                                                                                 grid.getEnergyService()),
                                                                         grid.getStorageService().getInventory(),
                                                                         toExportKey, amount, source,
                                                                         appeng.api.config.Actionable.MODULATE);
-                                                                fluidItem.fill(fuzzyFluid.toStack(amount),
-                                                                        net.minecraftforge.fluids.capability.IFluidHandler.FluidAction.EXECUTE);
-                                                                player.containerMenu.broadcastChanges();
-                                                            }
-                                                        }));
+                                                        if (actuallyExtracted <= 0) {
+                                                            continue;
+                                                        }
+
+                                                        int filled = fluidItem.fill(
+                                                                fuzzyFluid.toStack((int) actuallyExtracted),
+                                                                net.minecraftforge.fluids.capability.IFluidHandler.FluidAction.EXECUTE);
+                                                        if (filled < actuallyExtracted) {
+                                                            grid.getStorageService().getInventory().insert(toExportKey,
+                                                                    actuallyExtracted - filled,
+                                                                    appeng.api.config.Actionable.MODULATE, source);
+                                                        }
+                                                        player.getInventory().setItem(j,
+                                                                fluidItem.getContainer());
+                                                        player.containerMenu.broadcastChanges();
                                                     }
                                                 }
                                             }
@@ -339,5 +426,13 @@ public class AE2InsertExportCard {
                 }
             }
         }
+    }
+
+    private static boolean filterMatches(appeng.util.ConfigInventory filterConfig, appeng.api.stacks.AEKey key,
+            appeng.api.config.FuzzyMode fuzzyMode, boolean fuzzyInstalled) {
+        return filterConfig.getAvailableStacks().findFuzzy(key, fuzzyMode).stream()
+                .anyMatch(entry -> fuzzyInstalled
+                        ? key.fuzzyEquals(entry.getKey(), fuzzyMode)
+                        : key.equals(entry.getKey()));
     }
 }

--- a/src/main/java/com/ultramega/ae2insertexportcard/compat/AddonStorageBridge.java
+++ b/src/main/java/com/ultramega/ae2insertexportcard/compat/AddonStorageBridge.java
@@ -1,0 +1,81 @@
+package com.ultramega.ae2insertexportcard.compat;
+
+import appeng.api.config.FuzzyMode;
+import appeng.api.networking.IGrid;
+import appeng.api.networking.energy.IEnergySource;
+import appeng.api.networking.security.IActionSource;
+import appeng.api.stacks.AEKey;
+import appeng.util.ConfigInventory;
+import com.ultramega.ae2insertexportcard.compat.appbot.AppliedBotanicsCompat;
+import com.ultramega.ae2insertexportcard.compat.appmek.AppliedMekanisticsCompat;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fml.ModList;
+
+public final class AddonStorageBridge {
+    private AddonStorageBridge() {
+    }
+
+    public static boolean importFromItem(ServerPlayer player, IGrid grid, IEnergySource energySource,
+            IActionSource source, int inventorySlot, ItemStack itemStack, ConfigInventory filterConfig,
+            FuzzyMode fuzzyMode, boolean fuzzyInstalled, boolean invertFilter) {
+        if (ModList.get().isLoaded("appmek")) {
+            try {
+                if (AppliedMekanisticsCompat.importFromItem(player, grid, energySource, source, inventorySlot,
+                        itemStack, filterConfig, fuzzyMode, fuzzyInstalled, invertFilter)) {
+                    return true;
+                }
+            } catch (LinkageError ignored) {
+            }
+        }
+        if (ModList.get().isLoaded("appbot")) {
+            try {
+                return AppliedBotanicsCompat.importFromItem(player, grid, energySource, source, inventorySlot,
+                        itemStack, filterConfig, fuzzyMode, fuzzyInstalled, invertFilter);
+            } catch (LinkageError ignored) {
+            }
+        }
+        return false;
+    }
+
+    public static boolean isSupportedKey(AEKey key) {
+        if (ModList.get().isLoaded("appmek")) {
+            try {
+                if (AppliedMekanisticsCompat.isKey(key)) {
+                    return true;
+                }
+            } catch (LinkageError ignored) {
+            }
+        }
+        if (ModList.get().isLoaded("appbot")) {
+            try {
+                return AppliedBotanicsCompat.isKey(key);
+            } catch (LinkageError ignored) {
+            }
+        }
+        return false;
+    }
+
+    public static boolean exportToItem(ServerPlayer player, IGrid grid, IEnergySource energySource,
+            IActionSource source, int inventorySlot, ItemStack itemStack, AEKey key, long requestedAmount) {
+        if (ModList.get().isLoaded("appmek")) {
+            try {
+                if (AppliedMekanisticsCompat.isKey(key)) {
+                    return AppliedMekanisticsCompat.exportToItem(player, grid, energySource, source, inventorySlot,
+                            itemStack, key, requestedAmount);
+                }
+            } catch (LinkageError ignored) {
+            }
+        }
+        if (ModList.get().isLoaded("appbot")) {
+            try {
+                if (AppliedBotanicsCompat.isKey(key)) {
+                    return AppliedBotanicsCompat.exportToItem(player, grid, energySource, source, inventorySlot,
+                            itemStack, key, requestedAmount);
+                }
+            } catch (LinkageError ignored) {
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/ultramega/ae2insertexportcard/compat/ContainerTransferHelper.java
+++ b/src/main/java/com/ultramega/ae2insertexportcard/compat/ContainerTransferHelper.java
@@ -1,0 +1,113 @@
+package com.ultramega.ae2insertexportcard.compat;
+
+import appeng.api.behaviors.ContainerItemStrategy;
+import appeng.api.config.Actionable;
+import appeng.api.config.FuzzyMode;
+import appeng.api.networking.IGrid;
+import appeng.api.networking.energy.IEnergySource;
+import appeng.api.networking.security.IActionSource;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.GenericStack;
+import appeng.api.storage.StorageHelper;
+import appeng.util.ConfigInventory;
+import com.ultramega.ae2insertexportcard.util.AEKeyFilterUtil;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+
+public final class ContainerTransferHelper {
+    private ContainerTransferHelper() {
+    }
+
+    public static <K extends AEKey, C> boolean importFromItem(ContainerItemStrategy<K, C> strategy,
+            Class<K> keyClass, ServerPlayer player, IGrid grid, IEnergySource energySource, IActionSource source,
+            int inventorySlot, ItemStack itemStack, ConfigInventory filterConfig, FuzzyMode fuzzyMode,
+            boolean fuzzyInstalled, boolean invertFilter) {
+        GenericStack content = strategy.getContainedStack(itemStack);
+        if (content == null || content.amount() <= 0 || !keyClass.isInstance(content.what())) {
+            return false;
+        }
+
+        K key = keyClass.cast(content.what());
+        if (!AEKeyFilterUtil.passesFilter(key, filterConfig, fuzzyMode, fuzzyInstalled, invertFilter)) {
+            return false;
+        }
+
+        C context = strategy.findPlayerSlotContext(player, inventorySlot);
+        if (context == null) {
+            return false;
+        }
+
+        long extractable = strategy.extract(context, key, content.amount(), Actionable.SIMULATE);
+        if (extractable <= 0) {
+            return false;
+        }
+
+        long insertable = StorageHelper.poweredInsert(energySource, grid.getStorageService().getInventory(), key,
+                extractable, source, Actionable.SIMULATE);
+        if (insertable <= 0) {
+            return false;
+        }
+
+        long extracted = strategy.extract(context, key, Math.min(extractable, insertable), Actionable.MODULATE);
+        if (extracted <= 0) {
+            return false;
+        }
+
+        long inserted = StorageHelper.poweredInsert(energySource, grid.getStorageService().getInventory(), key,
+                extracted, source, Actionable.MODULATE);
+        if (inserted < extracted) {
+            strategy.insert(context, key, extracted - inserted, Actionable.MODULATE);
+        }
+
+        if (inserted > 0) {
+            player.getInventory().setItem(inventorySlot, itemStack);
+            player.containerMenu.broadcastChanges();
+            return true;
+        }
+        return false;
+    }
+
+    public static <K extends AEKey, C> boolean exportToItem(ContainerItemStrategy<K, C> strategy,
+            Class<K> keyClass, ServerPlayer player, IGrid grid, IEnergySource energySource, IActionSource source,
+            int inventorySlot, ItemStack itemStack, AEKey key, long requestedAmount) {
+        if (!keyClass.isInstance(key) || requestedAmount <= 0) {
+            return false;
+        }
+
+        K typedKey = keyClass.cast(key);
+        C context = strategy.findPlayerSlotContext(player, inventorySlot);
+        if (context == null) {
+            return false;
+        }
+
+        long insertable = strategy.insert(context, typedKey, requestedAmount, Actionable.SIMULATE);
+        if (insertable <= 0) {
+            return false;
+        }
+
+        long extractable = StorageHelper.poweredExtraction(energySource, grid.getStorageService().getInventory(),
+                typedKey, insertable, source, Actionable.SIMULATE);
+        if (extractable <= 0) {
+            return false;
+        }
+
+        long extracted = StorageHelper.poweredExtraction(energySource, grid.getStorageService().getInventory(),
+                typedKey, Math.min(insertable, extractable), source, Actionable.MODULATE);
+        if (extracted <= 0) {
+            return false;
+        }
+
+        long inserted = strategy.insert(context, typedKey, extracted, Actionable.MODULATE);
+        if (inserted < extracted) {
+            StorageHelper.poweredInsert(energySource, grid.getStorageService().getInventory(), typedKey,
+                    extracted - inserted, source, Actionable.MODULATE);
+        }
+
+        if (inserted > 0) {
+            player.getInventory().setItem(inventorySlot, itemStack);
+            player.containerMenu.broadcastChanges();
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/ultramega/ae2insertexportcard/compat/WirelessTerminalTicker.java
+++ b/src/main/java/com/ultramega/ae2insertexportcard/compat/WirelessTerminalTicker.java
@@ -1,0 +1,30 @@
+package com.ultramega.ae2insertexportcard.compat;
+
+import appeng.api.networking.IGrid;
+import appeng.helpers.WirelessTerminalMenuHost;
+import appeng.items.tools.powered.WirelessTerminalItem;
+import com.ultramega.ae2insertexportcard.AE2InsertExportCard;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+
+public final class WirelessTerminalTicker {
+    private WirelessTerminalTicker() {
+    }
+
+    public static void tick(ItemStack stack, ServerPlayer player, int slotId) {
+        if (!stack.hasTag() || !(stack.getItem() instanceof WirelessTerminalItem wirelessTerminalItem)) {
+            return;
+        }
+
+        var menuHost = wirelessTerminalItem.getMenuHost(player, slotId, stack, null);
+        if (!(menuHost instanceof WirelessTerminalMenuHost host) || !host.rangeCheck()) {
+            return;
+        }
+
+        var node = host.getActionableNode();
+        IGrid grid = node == null ? null : node.getGrid();
+        if (grid != null) {
+            AE2InsertExportCard.tickWireless(stack, grid, host, player);
+        }
+    }
+}

--- a/src/main/java/com/ultramega/ae2insertexportcard/compat/appbot/AppliedBotanicsCompat.java
+++ b/src/main/java/com/ultramega/ae2insertexportcard/compat/appbot/AppliedBotanicsCompat.java
@@ -1,0 +1,37 @@
+package com.ultramega.ae2insertexportcard.compat.appbot;
+
+import appbot.ae2.ManaContainerItemStrategy;
+import appbot.ae2.ManaKey;
+import appeng.api.config.FuzzyMode;
+import appeng.api.networking.IGrid;
+import appeng.api.networking.energy.IEnergySource;
+import appeng.api.networking.security.IActionSource;
+import appeng.api.stacks.AEKey;
+import appeng.util.ConfigInventory;
+import com.ultramega.ae2insertexportcard.compat.ContainerTransferHelper;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+
+public final class AppliedBotanicsCompat {
+    private static final ManaContainerItemStrategy STRATEGY = new ManaContainerItemStrategy();
+
+    private AppliedBotanicsCompat() {
+    }
+
+    public static boolean isKey(AEKey key) {
+        return key instanceof ManaKey;
+    }
+
+    public static boolean importFromItem(ServerPlayer player, IGrid grid, IEnergySource energySource,
+            IActionSource source, int inventorySlot, ItemStack itemStack, ConfigInventory filterConfig,
+            FuzzyMode fuzzyMode, boolean fuzzyInstalled, boolean invertFilter) {
+        return ContainerTransferHelper.importFromItem(STRATEGY, ManaKey.class, player, grid, energySource,
+                source, inventorySlot, itemStack, filterConfig, fuzzyMode, fuzzyInstalled, invertFilter);
+    }
+
+    public static boolean exportToItem(ServerPlayer player, IGrid grid, IEnergySource energySource,
+            IActionSource source, int inventorySlot, ItemStack itemStack, AEKey key, long requestedAmount) {
+        return ContainerTransferHelper.exportToItem(STRATEGY, ManaKey.class, player, grid, energySource,
+                source, inventorySlot, itemStack, key, requestedAmount);
+    }
+}

--- a/src/main/java/com/ultramega/ae2insertexportcard/compat/appmek/AppliedMekanisticsCompat.java
+++ b/src/main/java/com/ultramega/ae2insertexportcard/compat/appmek/AppliedMekanisticsCompat.java
@@ -1,0 +1,37 @@
+package com.ultramega.ae2insertexportcard.compat.appmek;
+
+import appeng.api.config.FuzzyMode;
+import appeng.api.networking.IGrid;
+import appeng.api.networking.energy.IEnergySource;
+import appeng.api.networking.security.IActionSource;
+import appeng.api.stacks.AEKey;
+import appeng.util.ConfigInventory;
+import com.ultramega.ae2insertexportcard.compat.ContainerTransferHelper;
+import me.ramidzkh.mekae2.ae2.ChemicalContainerItemStrategy;
+import me.ramidzkh.mekae2.ae2.MekanismKey;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+
+public final class AppliedMekanisticsCompat {
+    private static final ChemicalContainerItemStrategy STRATEGY = new ChemicalContainerItemStrategy();
+
+    private AppliedMekanisticsCompat() {
+    }
+
+    public static boolean isKey(AEKey key) {
+        return key instanceof MekanismKey;
+    }
+
+    public static boolean importFromItem(ServerPlayer player, IGrid grid, IEnergySource energySource,
+            IActionSource source, int inventorySlot, ItemStack itemStack, ConfigInventory filterConfig,
+            FuzzyMode fuzzyMode, boolean fuzzyInstalled, boolean invertFilter) {
+        return ContainerTransferHelper.importFromItem(STRATEGY, MekanismKey.class, player, grid, energySource,
+                source, inventorySlot, itemStack, filterConfig, fuzzyMode, fuzzyInstalled, invertFilter);
+    }
+
+    public static boolean exportToItem(ServerPlayer player, IGrid grid, IEnergySource energySource,
+            IActionSource source, int inventorySlot, ItemStack itemStack, AEKey key, long requestedAmount) {
+        return ContainerTransferHelper.exportToItem(STRATEGY, MekanismKey.class, player, grid, energySource,
+                source, inventorySlot, itemStack, key, requestedAmount);
+    }
+}

--- a/src/main/java/com/ultramega/ae2insertexportcard/container/UpgradeContainerMenu.java
+++ b/src/main/java/com/ultramega/ae2insertexportcard/container/UpgradeContainerMenu.java
@@ -31,6 +31,10 @@ public class UpgradeContainerMenu extends AEBaseMenu implements ISubMenu {
     public static final MenuType<UpgradeContainerMenu> TYPE_EXPORT = MenuTypeBuilder.create((id, inventory, host) -> new UpgradeContainerMenu(UpgradeType.EXPORT, id, inventory, host, new UpgradeHost(UpgradeType.EXPORT, id, inventory, host)), WirelessTerminalMenuHost.class)
             .build(EXPORT_CARD_ID);
 
+    public static void init() {
+        // Invoking this method initializes the class and queues both menu types in AE2.
+    }
+
     private final UpgradeType type;
     private final WirelessTerminalMenuHost host;
     private final UpgradeHost upgradeHost;
@@ -87,6 +91,10 @@ public class UpgradeContainerMenu extends AEBaseMenu implements ISubMenu {
 
     public UpgradeHost getUpgradeHost() {
         return upgradeHost;
+    }
+
+    public UpgradeType getUpgradeType() {
+        return type;
     }
 
     @Override

--- a/src/main/java/com/ultramega/ae2insertexportcard/item/UpgradeHost.java
+++ b/src/main/java/com/ultramega/ae2insertexportcard/item/UpgradeHost.java
@@ -21,6 +21,7 @@ import net.minecraft.world.item.ItemStack;
 
 public class UpgradeHost implements IConfigurableObject {
     public static final String NBT_SELECTED_INVENTORY_SLOTS = "SelectedInventorySlots";
+    private static final int INVENTORY_SLOT_COUNT = 36;
 
     public final ConfigInventory filterConfig = ConfigInventory.configTypes(18, this::updateFilter);
     private IConfigManager configManager;
@@ -88,6 +89,9 @@ public class UpgradeHost implements IConfigurableObject {
     }
 
     public void setSelectedInventorySlots(int[] selectedInventorySlots) {
+        if (selectedInventorySlots.length != INVENTORY_SLOT_COUNT) {
+            return;
+        }
         ListTag tagList = itemStack.getTag().getList("upgrades", Tag.TAG_COMPOUND);
         for (int i = 0; i < tagList.size(); i++) {
             if (isInsertOrExportCard(type, tagList, i)) {
@@ -111,12 +115,15 @@ public class UpgradeHost implements IConfigurableObject {
                 CompoundTag tag = (CompoundTag) tagList.getCompound(i).get("tag");
 
                 if (tag != null && tag.contains(NBT_SELECTED_INVENTORY_SLOTS)) {
-                    return tag.getIntArray(NBT_SELECTED_INVENTORY_SLOTS);
+                    int[] selectedSlots = tag.getIntArray(NBT_SELECTED_INVENTORY_SLOTS);
+                    return selectedSlots.length == INVENTORY_SLOT_COUNT
+                            ? selectedSlots
+                            : new int[INVENTORY_SLOT_COUNT];
                 }
             }
         }
 
-        return new int[36];
+        return new int[INVENTORY_SLOT_COUNT];
     }
 
     public boolean isInsertOrExportCard(UpgradeType type, ListTag tagList, int index) {

--- a/src/main/java/com/ultramega/ae2insertexportcard/mixin/MixinConfigPlugin.java
+++ b/src/main/java/com/ultramega/ae2insertexportcard/mixin/MixinConfigPlugin.java
@@ -1,0 +1,47 @@
+package com.ultramega.ae2insertexportcard.mixin;
+
+import net.minecraftforge.fml.loading.LoadingModList;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public final class MixinConfigPlugin implements IMixinConfigPlugin {
+    private static final String WUT_MIXIN = "com.ultramega.ae2insertexportcard.mixin.MixinWUTItem";
+
+    @Override
+    public void onLoad(String mixinPackage) {
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return !WUT_MIXIN.equals(mixinClassName)
+                || LoadingModList.get().getModFileById("ae2wtlib") != null;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName,
+            IMixinInfo mixinInfo) {
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName,
+            IMixinInfo mixinInfo) {
+    }
+}

--- a/src/main/java/com/ultramega/ae2insertexportcard/mixin/MixinWUTItem.java
+++ b/src/main/java/com/ultramega/ae2insertexportcard/mixin/MixinWUTItem.java
@@ -1,68 +1,22 @@
 package com.ultramega.ae2insertexportcard.mixin;
 
-import appeng.api.networking.IGrid;
-import appeng.api.networking.crafting.ICraftingPlan;
-import appeng.helpers.WirelessTerminalMenuHost;
-import appeng.items.tools.powered.WirelessTerminalItem;
+import com.ultramega.ae2insertexportcard.compat.WirelessTerminalTicker;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.concurrent.Future;
-
 @Mixin(targets = "de.mari_023.ae2wtlib.wut.ItemWUT")
 public class MixinWUTItem {
-    @Unique
-    private Future<ICraftingPlan> ae2insertExportCard$craftingJob;
-
-    @Inject(method = "inventoryTick", at = @At("HEAD"), remap = false)
-    public void ae2insertExportCard_inventoryTick(ItemStack stack, Level level, Entity entity, int slotId,
+    @Inject(method = { "inventoryTick", "m_6883_" }, at = @At("HEAD"), remap = false)
+    private void ae2insertExportCard$inventoryTick(ItemStack stack, Level level, Entity entity, int slotId,
             boolean isSelected, CallbackInfo ci) {
-        if (level.isClientSide())
-            return;
-        if (!(entity instanceof ServerPlayer player))
-            return;
-
-        if (!stack.hasTag())
-            return;
-
-        // Check if in access point range
-        boolean inRange = false;
-        IGrid mutableGrid = null;
-        WirelessTerminalMenuHost host = null;
-
-        if (stack.getItem() instanceof WirelessTerminalItem wirelessTerminalItem) {
-            var menuHost = wirelessTerminalItem.getMenuHost(player, slotId, stack, null);
-            if (menuHost != null) {
-                try {
-                    host = (WirelessTerminalMenuHost) menuHost;
-                    boolean check = host.rangeCheck();
-                    if (check) {
-                        inRange = true;
-                        var node = host.getActionableNode();
-                        if (node != null) {
-                            mutableGrid = node.getGrid();
-                        }
-                    }
-                } catch (ClassCastException e) {
-                    // Ignore
-                }
-            }
+        if (!level.isClientSide() && entity instanceof ServerPlayer player) {
+            WirelessTerminalTicker.tick(stack, player, slotId);
         }
-
-        final IGrid grid = mutableGrid;
-
-        if (!inRange)
-            return;
-
-        com.ultramega.ae2insertexportcard.AE2InsertExportCard.tickWireless(stack, grid, host, player,
-                () -> this.ae2insertExportCard$craftingJob,
-                (job) -> this.ae2insertExportCard$craftingJob = job);
     }
 }

--- a/src/main/java/com/ultramega/ae2insertexportcard/mixin/MixinWirelessCraftingTerminalItem.java
+++ b/src/main/java/com/ultramega/ae2insertexportcard/mixin/MixinWirelessCraftingTerminalItem.java
@@ -1,71 +1,29 @@
 package com.ultramega.ae2insertexportcard.mixin;
 
-import appeng.api.networking.IGrid;
-import appeng.api.networking.crafting.ICraftingPlan;
-import appeng.helpers.WirelessTerminalMenuHost;
 import appeng.items.tools.powered.WirelessCraftingTerminalItem;
-import appeng.items.tools.powered.WirelessTerminalItem;
+import com.ultramega.ae2insertexportcard.compat.WirelessTerminalTicker;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.concurrent.Future;
-
-@Mixin(WirelessCraftingTerminalItem.class)
-public abstract class MixinWirelessCraftingTerminalItem extends Item {
-
-    public MixinWirelessCraftingTerminalItem(Properties properties) {
-        super(properties);
-    }
-
-    @Unique
-    private Future<ICraftingPlan> ae2insertExportCard$craftingJob;
-
-    @Override
-    public void inventoryTick(ItemStack stack, Level level, Entity entity, int slotId, boolean isSelected) {
-        if (level.isClientSide())
-            return;
-        if (!(entity instanceof ServerPlayer player))
-            return;
-
-        if (!stack.hasTag())
-            return;
-
-        // Check if in access point range
-        boolean inRange = false;
-        IGrid mutableGrid = null;
-        WirelessTerminalMenuHost host = null;
-
-        if (stack.getItem() instanceof WirelessTerminalItem wirelessTerminalItem) {
-            var menuHost = wirelessTerminalItem.getMenuHost(player, slotId, stack, null);
-            if (menuHost != null) {
-                try {
-                    host = (WirelessTerminalMenuHost) menuHost;
-                    boolean check = host.rangeCheck();
-                    if (check) {
-                        inRange = true;
-                        var node = host.getActionableNode();
-                        if (node != null) {
-                            mutableGrid = node.getGrid();
-                        }
-                    }
-                } catch (ClassCastException e) {
-                    // Ignore
-                }
-            }
+/**
+ * AE2WTLib adds an inventoryTick override to the crafting terminal. Injecting
+ * after that optional mixin preserves both behaviours without competing
+ * overwrites. Without AE2WTLib there is no declared method here and the base
+ * wireless-terminal mixin handles the inherited tick.
+ */
+@Mixin(value = WirelessCraftingTerminalItem.class, priority = 900)
+public class MixinWirelessCraftingTerminalItem {
+    @Inject(method = { "inventoryTick", "m_6883_" }, at = @At("HEAD"), remap = false, require = 0)
+    private void ae2insertExportCard$inventoryTick(ItemStack stack, Level level, Entity entity, int slotId,
+            boolean isSelected, CallbackInfo ci) {
+        if (!level.isClientSide() && entity instanceof ServerPlayer player) {
+            WirelessTerminalTicker.tick(stack, player, slotId);
         }
-
-        final IGrid grid = mutableGrid;
-
-        if (!inRange)
-            return;
-
-        com.ultramega.ae2insertexportcard.AE2InsertExportCard.tickWireless(stack, grid, host, player,
-                () -> this.ae2insertExportCard$craftingJob,
-                (job) -> this.ae2insertExportCard$craftingJob = job);
     }
 }

--- a/src/main/java/com/ultramega/ae2insertexportcard/mixin/MixinWirelessTerminalItem.java
+++ b/src/main/java/com/ultramega/ae2insertexportcard/mixin/MixinWirelessTerminalItem.java
@@ -1,75 +1,24 @@
 package com.ultramega.ae2insertexportcard.mixin;
 
-import appeng.api.networking.IGrid;
-import appeng.api.networking.crafting.ICraftingPlan;
-import appeng.helpers.WirelessTerminalMenuHost;
 import appeng.items.tools.powered.WirelessTerminalItem;
+import com.ultramega.ae2insertexportcard.compat.WirelessTerminalTicker;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
-
-import java.util.concurrent.Future;
 
 @Mixin(WirelessTerminalItem.class)
 public abstract class MixinWirelessTerminalItem extends Item {
-
     public MixinWirelessTerminalItem(Properties properties) {
         super(properties);
     }
 
-    @Unique
-    private Future<ICraftingPlan> ae2insertExportCard$craftingJob;
-
     @Override
     public void inventoryTick(ItemStack stack, Level level, Entity entity, int slotId, boolean isSelected) {
-        if (level.isClientSide())
-            return;
-        if (!(entity instanceof ServerPlayer player))
-            return;
-
-        if (!stack.hasTag())
-            return;
-
-        if (!stack.hasTag()) return;
-        // 
-        
-        // Check if in access point range
-
-        // Check if in access point range
-        boolean inRange = false;
-        IGrid mutableGrid = null;
-        WirelessTerminalMenuHost host = null;
-
-        if (stack.getItem() instanceof WirelessTerminalItem wirelessTerminalItem) {
-            var menuHost = wirelessTerminalItem.getMenuHost(player, slotId, stack, null);
-            if (menuHost != null) {
-                try {
-                    host = (WirelessTerminalMenuHost) menuHost;
-                    boolean check = host.rangeCheck();
-                    if (check) {
-                        inRange = true;
-                        var node = host.getActionableNode();
-                        if (node != null) {
-                            mutableGrid = node.getGrid();
-                        }
-                    }
-                } catch (ClassCastException e) {
-                    // Ignore
-                }
-            }
+        if (!level.isClientSide() && entity instanceof ServerPlayer player) {
+            WirelessTerminalTicker.tick(stack, player, slotId);
         }
-
-        final IGrid grid = mutableGrid;
-
-        if (!inRange)
-            return;
-
-        com.ultramega.ae2insertexportcard.AE2InsertExportCard.tickWireless(stack, grid, host, player,
-                () -> this.ae2insertExportCard$craftingJob,
-                (job) -> this.ae2insertExportCard$craftingJob = job);
     }
 }

--- a/src/main/java/com/ultramega/ae2insertexportcard/network/LockSlotUpdateMessage.java
+++ b/src/main/java/com/ultramega/ae2insertexportcard/network/LockSlotUpdateMessage.java
@@ -28,9 +28,11 @@ public class LockSlotUpdateMessage {
 
     public static void handle(LockSlotUpdateMessage message, Supplier<NetworkEvent.Context> ctx) {
         Player player = ctx.get().getSender();
-        if (player != null && player.containerMenu instanceof UpgradeContainerMenu) {
+        if (player != null) {
             ctx.get().enqueueWork(() -> {
-                if(player.containerMenu.slots.get(message.slotId) instanceof CardPlayerSlot playerSlot) {
+                if (player.containerMenu instanceof UpgradeContainerMenu
+                        && message.slotId >= 0 && message.slotId < player.containerMenu.slots.size()
+                        && player.containerMenu.slots.get(message.slotId) instanceof CardPlayerSlot playerSlot) {
                     playerSlot.setCancelPickup(message.cancelPickup);
                 }
             });

--- a/src/main/java/com/ultramega/ae2insertexportcard/network/UpgradeUpdateMessage.java
+++ b/src/main/java/com/ultramega/ae2insertexportcard/network/UpgradeUpdateMessage.java
@@ -8,6 +8,8 @@ import net.minecraftforge.network.NetworkEvent;
 import java.util.function.Supplier;
 
 public class UpgradeUpdateMessage {
+    private static final int INVENTORY_SLOT_COUNT = 36;
+
     private final int type;
     private final int[] selectedInventorySlots;
 
@@ -17,7 +19,7 @@ public class UpgradeUpdateMessage {
     }
 
     public static UpgradeUpdateMessage decode(FriendlyByteBuf buf) {
-        return new UpgradeUpdateMessage(buf.readInt(), buf.readVarIntArray());
+        return new UpgradeUpdateMessage(buf.readInt(), buf.readVarIntArray(INVENTORY_SLOT_COUNT));
     }
 
     public static void encode(UpgradeUpdateMessage message, FriendlyByteBuf buf) {
@@ -27,10 +29,30 @@ public class UpgradeUpdateMessage {
 
     public static void handle(UpgradeUpdateMessage message, Supplier<NetworkEvent.Context> ctx) {
         Player player = ctx.get().getSender();
-        if (player != null && player.containerMenu instanceof UpgradeContainerMenu containerMenu) {
-            ctx.get().enqueueWork(() -> containerMenu.getUpgradeHost().setSelectedInventorySlots(message.selectedInventorySlots));
+        if (player != null) {
+            ctx.get().enqueueWork(() -> {
+                if (player.containerMenu instanceof UpgradeContainerMenu containerMenu
+                        && isValid(message, containerMenu)) {
+                    containerMenu.getUpgradeHost().setSelectedInventorySlots(message.selectedInventorySlots);
+                }
+            });
         }
 
         ctx.get().setPacketHandled(true);
+    }
+
+    private static boolean isValid(UpgradeUpdateMessage message, UpgradeContainerMenu menu) {
+        if (message.type != menu.getUpgradeType().getId()
+                || message.selectedInventorySlots.length != INVENTORY_SLOT_COUNT) {
+            return false;
+        }
+
+        int maximum = message.type == 0 ? 1 : 18;
+        for (int selection : message.selectedInventorySlots) {
+            if (selection < 0 || selection > maximum) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/main/java/com/ultramega/ae2insertexportcard/registry/ModMenuTypes.java
+++ b/src/main/java/com/ultramega/ae2insertexportcard/registry/ModMenuTypes.java
@@ -1,17 +1,9 @@
 package com.ultramega.ae2insertexportcard.registry;
 
-import appeng.core.AppEng;
 import com.ultramega.ae2insertexportcard.container.UpgradeContainerMenu;
-import net.minecraft.world.inventory.MenuType;
-import net.minecraftforge.registries.ForgeRegistries;
 
 public class ModMenuTypes {
     public static void init() {
-        registerMenuType(UpgradeContainerMenu.INSERT_CARD_ID, UpgradeContainerMenu.TYPE_INSERT);
-        registerMenuType(UpgradeContainerMenu.EXPORT_CARD_ID, UpgradeContainerMenu.TYPE_EXPORT);
-    }
-
-    public static void registerMenuType(String id, MenuType<?> menuType) {
-        ForgeRegistries.MENU_TYPES.register(AppEng.makeId(id), menuType);
+        UpgradeContainerMenu.init();
     }
 }

--- a/src/main/java/com/ultramega/ae2insertexportcard/util/AEKeyFilterUtil.java
+++ b/src/main/java/com/ultramega/ae2insertexportcard/util/AEKeyFilterUtil.java
@@ -1,0 +1,19 @@
+package com.ultramega.ae2insertexportcard.util;
+
+import appeng.api.config.FuzzyMode;
+import appeng.api.stacks.AEKey;
+import appeng.util.ConfigInventory;
+
+public final class AEKeyFilterUtil {
+    private AEKeyFilterUtil() {
+    }
+
+    public static boolean passesFilter(AEKey key, ConfigInventory filterConfig, FuzzyMode fuzzyMode,
+            boolean fuzzyInstalled, boolean invertFilter) {
+        boolean matches = filterConfig.getAvailableStacks().findFuzzy(key, fuzzyMode).stream()
+                .anyMatch(entry -> fuzzyInstalled
+                        ? key.fuzzyEquals(entry.getKey(), fuzzyMode)
+                        : key.equals(entry.getKey()));
+        return invertFilter != matches;
+    }
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -15,20 +15,41 @@ description="This mod adds a Insert and Export Card."
 [[dependencies.ae2insertexportcard]]
     modId="ae2"
     mandatory=true
-    versionRange="[12,)"
+    versionRange="[12.9.9,13)"
     ordering="NONE"
     side="BOTH"
 
 [[dependencies.ae2insertexportcard]]
     modId="forge"
     mandatory=true
-    versionRange="[43,)"
+    versionRange="[43,44)"
     ordering="NONE"
     side="BOTH"
 
 [[dependencies.ae2insertexportcard]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.19.2,1.20)"
+    versionRange="[1.19.2,1.19.3)"
     ordering="NONE"
+    side="BOTH"
+
+[[dependencies.ae2insertexportcard]]
+    modId="ae2wtlib"
+    mandatory=false
+    versionRange="[12.9.7,13)"
+    ordering="AFTER"
+    side="BOTH"
+
+[[dependencies.ae2insertexportcard]]
+    modId="appmek"
+    mandatory=false
+    versionRange="[1.3.5,2)"
+    ordering="AFTER"
+    side="BOTH"
+
+[[dependencies.ae2insertexportcard]]
+    modId="appbot"
+    mandatory=false
+    versionRange="[1.4.6,2)"
+    ordering="AFTER"
     side="BOTH"

--- a/src/main/resources/ae2insertexportcard.mixins.json
+++ b/src/main/resources/ae2insertexportcard.mixins.json
@@ -1,6 +1,7 @@
 {
   "required": true,
   "package": "com.ultramega.ae2insertexportcard.mixin",
+  "plugin": "com.ultramega.ae2insertexportcard.mixin.MixinConfigPlugin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "MixinMEStorageMenu",

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -3,6 +3,6 @@
     "description": {
       "text": "AE2 Insert Export Card resources"
     },
-    "pack_format": 15
+    "pack_format": 9
   }
 }


### PR DESCRIPTION
这是对之前 1.19.2 移植的一次兼容性与稳定性修复。它解决了整合包环境中的启动、进世界崩溃和传输一致性问题，并补充了 Mekanism 化学品与 Botania Mana 支持。

主要改动：

- 修复未安装 AE2WTLib 时的 Mixin 加载问题。
- 修复普通无线终端、无线合成终端与 WUT 之间的 Tick/Mixin 冲突。
- 修复物品与流体部分传输时可能出现的资源丢失或不一致问题。
- 将合成任务状态按终端物品栈隔离，避免不同终端或玩家共享任务。
- 增加菜单注册、槽位范围和客户端数据包校验。
- 修正 Minecraft、Forge、AE2 的依赖范围以及 1.19.2 资源包格式。
- 通过 Applied Mekanistics 原生容器接口支持气体、灌注类型、颜料和浆液的导入/导出。
- 通过 Applied Botanics 原生容器接口支持 Mana 导入/导出。
- AE2WTLib、Applied Mekanistics 和 Applied Botanics 均保持为可选依赖。

---

This PR provides a compatibility and stability update for the previous Minecraft 1.19.2 backport. It fixes startup, world-loading crashes, and transfer consistency issues found in a real modpack environment, while adding Mekanism chemical and Botania mana support.

Main changes:

- Fixed Mixin loading when AE2WTLib is not installed.
- Fixed tick/Mixin conflicts between the standard wireless terminal, wireless crafting terminal, and WUT.
- Fixed potential item and fluid loss or inconsistency during partial transfers.
- Isolated crafting job state per terminal stack to prevent different terminals or players from sharing the same job.
- Added validation for menu registration, slot ranges, and client network messages.
- Corrected the Minecraft, Forge, and AE2 dependency ranges and the resource-pack format for 1.19.2.
- Added import/export support for gases, infuse types, pigments, and slurries through Applied Mekanistics' native container strategy.
- Added mana import/export support through Applied Botanics' native container strategy.
- AE2WTLib, Applied Mekanistics, and Applied Botanics remain optional dependencies.